### PR TITLE
chore: criar arquivos de configurações de formatação

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+node_modules
+
+.vscode
+
+*.config.js
+*.lock

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,9 @@
+node_modules
+
+.vscode
+
+.env
+
+.expo
+
+*.lock


### PR DESCRIPTION
Adição dos arquivos .prettierignore e .eslintignore, permitindo formatar apenas os arquivos relevantes para tal